### PR TITLE
Extend FMP MCP with additional financial statements, peer comparison, and representative tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A Model Context Protocol (MCP) server that provides tools, resources, and prompts for financial analysis using the Financial Modeling Prep API.
 
+⚠️ **Fork notice** 15 Jan 2026
+This is a temporary fork of `cdtait/fmp-mcp-server` containing proposed extensions to the Financial Modeling Prep (FMP) MCP server.
+The changes are intended to be upstreamed via Pull Request.
+
 ## Features
 
 - **Company Information**: Access detailed company profiles and peer comparisons

--- a/README.md
+++ b/README.md
@@ -2,9 +2,14 @@
 
 A Model Context Protocol (MCP) server that provides tools, resources, and prompts for financial analysis using the Financial Modeling Prep API.
 
-⚠️ **Fork notice** 15 Jan 2026
+⚠️ **Fork notice** 15 Jan 2026 (updated 14 Feb 2026)
 This is a temporary fork of `cdtait/fmp-mcp-server` containing proposed extensions to the Financial Modeling Prep (FMP) MCP server.
 The changes are intended to be upstreamed via Pull Request.
+Extensions added in this fork:
+- **DCF Valuation tools** (14 Feb 2026): Four new tools exposing FMP's discounted cash flow endpoints:
+  `get_discounted_cash_flow`, `get_levered_discounted_cash_flow`,
+  `get_custom_discounted_cash_flow` (with optional scenario overrides for bull/base/bear analysis),
+  `get_custom_levered_dcf`
 
 ## Features
 
@@ -23,6 +28,7 @@ The changes are intended to be upstreamed via Pull Request.
 - **Cryptocurrencies**: Access cryptocurrency listings and current quotes
 - **Forex**: Get forex pair listings and exchange rates
 - **Technical Indicators**: Calculate and interpret Exponential Moving Average (EMA)
+- **DCF Valuation**: Discounted cash flow valuation (standard, levered, and custom with scenario overrides)
 - **Analysis Prompts**: Generate investment analyses using predefined prompt templates
 - **Chat Agent**: Interactive CLI chat interface to FMP MCP Server
 - **Multiple Transport Options**: Support for stdio, SSE, and Streamable HTTP transports
@@ -49,6 +55,7 @@ The codebase is organized to align with the FMP API documentation structure foun
 - **search.py**: API for searching tickers and companies
 - **statements.py**: Financial statements (income, balance sheet, cash flow, ratios)
 - **technical_indicators.py**: Technical indicators and analysis
+- **valuation.py**: DCF valuation tools (discounted cash flow, levered DCF, custom DCF with scenario overrides)
 
 ### API Endpoint Standardization
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,25 @@
 
 A Model Context Protocol (MCP) server that provides tools, resources, and prompts for financial analysis using the Financial Modeling Prep API.
 
+> **SUPERSEDED -- 2026-03-07**
+> FMP now publishes an official hosted MCP server that wraps their full REST API (~250 tools).
+> This fork is no longer maintained. Use the official server instead.
+>
+> **Official FMP MCP documentation:** https://site.financialmodelingprep.com/developer/docs/mcp-server
+>
+> **Config (add to `.mcp.json` or equivalent MCP client config):**
+> ```json
+> "FMP-MCP-Official": {
+>   "type": "http",
+>   "url": "https://financialmodelingprep.com/mcp?apikey=YOUR_FMP_API_KEY"
+> }
+> ```
+>
+> Use your existing FMP API key. Use `"type": "http"` -- `"type": "sse"` does not work.
+> Note: the official docs page may return HTTP 403 for automated fetches; the config above is all you need.
+
+---
+
 ⚠️ **Fork notice** 15 Jan 2026 (updated 14 Feb 2026)
 This is a temporary fork of `cdtait/fmp-mcp-server` containing proposed extensions to the Financial Modeling Prep (FMP) MCP server.
 The changes are intended to be upstreamed via Pull Request.

--- a/server.py
+++ b/server.py
@@ -1,0 +1,13 @@
+import sys
+from pathlib import Path
+
+# Ensure project root is on PYTHONPATH (Claude Desktop safe)
+PROJECT_ROOT = Path(__file__).resolve().parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+# Import the real server module
+import src.server as real_server
+
+# Explicitly start the MCP server
+real_server.mcp.run()

--- a/src/server.py
+++ b/src/server.py
@@ -70,6 +70,12 @@ from src.tools.commodities import get_commodities_list, get_commodities_prices, 
 from src.tools.crypto import get_crypto_list, get_crypto_quote
 from src.tools.forex import get_forex_list, get_forex_quotes
 from src.tools.technical_indicators import get_ema
+from src.tools.valuation import (
+    get_discounted_cash_flow,
+    get_levered_discounted_cash_flow,
+    get_custom_discounted_cash_flow,
+    get_custom_levered_dcf,
+)
 
 # Import resources
 from src.resources.company import get_stock_info_resource, get_financial_statement_resource, get_stock_peers_resource, get_price_targets_resource
@@ -160,6 +166,12 @@ mcp.tool()(get_forex_list)
 mcp.tool()(get_forex_quotes)
 mcp.tool()(get_ema)
 
+# --- DCF Valuation ---
+mcp.tool()(get_discounted_cash_flow)
+mcp.tool()(get_levered_discounted_cash_flow)
+mcp.tool()(get_custom_discounted_cash_flow)
+mcp.tool()(get_custom_levered_dcf)
+
 # Register resources
 mcp.resource("stock-info://{symbol}")(get_stock_info_resource)
 mcp.resource("market-snapshot://current")(get_market_snapshot_resource)
@@ -243,14 +255,22 @@ if __name__ == "__main__":
         from mcp.server.fastmcp import FastMCP
         
         # Create new FastMCP instance with desired configuration
+
+        # OLD SYNTAX UPDATED 
+        # streamable_mcp = FastMCP(
+        #     "FMP Financial Data",
+        #     description="Financial data tools and resources powered by Financial Modeling Prep API",
+        #     dependencies=["httpx"],
+        #     stateless_http=args.stateless,
+        #     json_response=args.json_response
+        # )
+        
         streamable_mcp = FastMCP(
             "FMP Financial Data",
-            description="Financial data tools and resources powered by Financial Modeling Prep API",
-            dependencies=["httpx"],
             stateless_http=args.stateless,
             json_response=args.json_response
         )
-        
+
         # Re-register all tools using the same decorators approach
         # Import tools
         from src.tools.company import get_company_profile, get_company_notes
@@ -269,7 +289,13 @@ if __name__ == "__main__":
         from src.tools.crypto import get_crypto_list, get_crypto_quote
         from src.tools.forex import get_forex_list, get_forex_quotes
         from src.tools.technical_indicators import get_ema
-        
+        from src.tools.valuation import (
+            get_discounted_cash_flow,
+            get_levered_discounted_cash_flow,
+            get_custom_discounted_cash_flow,
+            get_custom_levered_dcf,
+        )
+
         # Import resources
         from src.resources.company import get_stock_info_resource, get_stock_peers_resource, get_price_targets_resource
         # get_financial_statement_resource not currently used
@@ -342,7 +368,13 @@ if __name__ == "__main__":
         streamable_mcp.tool()(get_forex_list)
         streamable_mcp.tool()(get_forex_quotes)
         streamable_mcp.tool()(get_ema)
-        
+
+        # --- DCF Valuation ---
+        streamable_mcp.tool()(get_discounted_cash_flow)
+        streamable_mcp.tool()(get_levered_discounted_cash_flow)
+        streamable_mcp.tool()(get_custom_discounted_cash_flow)
+        streamable_mcp.tool()(get_custom_levered_dcf)
+
         # Register resources
         streamable_mcp.resource("stock-info://{symbol}")(get_stock_info_resource)
         streamable_mcp.resource("market-snapshot://current")(get_market_snapshot_resource)

--- a/src/server.py
+++ b/src/server.py
@@ -6,6 +6,16 @@ the Financial Modeling Prep API via the Model Context Protocol.
 """
 import os
 import pathlib
+
+# Start - New section added to fix the path errors
+import sys
+from pathlib import Path
+# Ensure project root is on PYTHONPATH for Claude Desktop (Windows STDIO)
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+# End - New section added to fix the path errors
+
 from dotenv import load_dotenv
 
 # Load environment variables from .env file
@@ -15,7 +25,38 @@ from mcp.server.fastmcp import FastMCP, Context
 
 # Import tools
 from src.tools.company import get_company_profile, get_company_notes
-from src.tools.statements import get_income_statement
+
+from src.tools.statements import (
+    get_income_statement,
+    get_balance_sheet,
+    get_cash_flow_statement,
+
+    # TTM statements
+    get_income_statement_ttm,
+    get_balance_sheet_ttm,
+    get_cash_flow_statement_ttm,
+
+    # Metrics & ratios
+    get_key_metrics,
+    get_key_metrics_ttm,
+    get_financial_ratios,
+    get_financial_ratios_ttm,
+    get_financial_scores,
+    get_owner_earnings,
+    get_enterprise_values,
+
+    # Growth
+    get_income_statement_growth,
+    get_balance_sheet_growth,
+    get_cash_flow_growth,
+    get_financial_statement_growth,
+
+    # Segmentation
+    get_revenue_product_segmentation,
+    get_revenue_geographic_segmentation,)
+
+from src.tools.peers import get_stock_peers
+
 from src.tools.search import search_by_symbol, search_by_name
 from src.tools.quote import get_quote, get_quote_change, get_aftermarket_quote
 from src.tools.charts import get_price_change
@@ -42,11 +83,15 @@ from src.prompts.templates import (
 )
 
 # Create the MCP server
-mcp = FastMCP(
-    "FMP Financial Data",
-    description="Financial data tools and resources powered by Financial Modeling Prep API",
-    dependencies=["httpx"]
-)
+
+# OLD version
+# mcp = FastMCP(
+#     "FMP Financial Data",
+#     description="Financial data tools and resources powered by Financial Modeling Prep API",
+#     dependencies=["httpx"]
+# )
+
+mcp = FastMCP("FMP Financial Data")
 
 # Register tools
 mcp.tool()(get_company_profile)
@@ -56,6 +101,36 @@ mcp.tool()(get_quote_change)
 mcp.tool()(get_aftermarket_quote)
 mcp.tool()(get_price_change)
 mcp.tool()(get_income_statement)
+mcp.tool()(get_balance_sheet)
+mcp.tool()(get_cash_flow_statement)
+
+# --- TTM Statements ---
+mcp.tool()(get_income_statement_ttm)
+mcp.tool()(get_balance_sheet_ttm)
+mcp.tool()(get_cash_flow_statement_ttm)
+
+# --- Metrics & Ratios ---
+mcp.tool()(get_key_metrics)
+mcp.tool()(get_key_metrics_ttm)
+mcp.tool()(get_financial_ratios)
+mcp.tool()(get_financial_ratios_ttm)
+mcp.tool()(get_financial_scores)
+mcp.tool()(get_owner_earnings)
+mcp.tool()(get_enterprise_values)
+
+# --- Growth ---
+mcp.tool()(get_income_statement_growth)
+mcp.tool()(get_balance_sheet_growth)
+mcp.tool()(get_cash_flow_growth)
+mcp.tool()(get_financial_statement_growth)
+
+# --- Segmentation ---
+mcp.tool()(get_revenue_product_segmentation)
+mcp.tool()(get_revenue_geographic_segmentation)
+
+# --- Peer comparison ---
+mcp.tool()(get_stock_peers)
+
 mcp.tool()(search_by_symbol)
 mcp.tool()(search_by_name)
 mcp.tool()(get_ratings_snapshot)
@@ -179,7 +254,7 @@ if __name__ == "__main__":
         # Re-register all tools using the same decorators approach
         # Import tools
         from src.tools.company import get_company_profile, get_company_notes
-        from src.tools.statements import get_income_statement
+        from src.tools.statements import get_income_statement,get_balance_sheet,get_cash_flow_statement
         from src.tools.search import search_by_symbol, search_by_name
         from src.tools.quote import get_quote, get_quote_change, get_aftermarket_quote
         from src.tools.charts import get_price_change
@@ -215,6 +290,36 @@ if __name__ == "__main__":
         streamable_mcp.tool()(get_aftermarket_quote)
         streamable_mcp.tool()(get_price_change)
         streamable_mcp.tool()(get_income_statement)
+        streamable_mcp.tool()(get_balance_sheet)
+        streamable_mcp.tool()(get_cash_flow_statement)
+
+        # --- TTM Statements ---
+        streamable_mcp.tool()(get_income_statement_ttm)
+        streamable_mcp.tool()(get_balance_sheet_ttm)
+        streamable_mcp.tool()(get_cash_flow_statement_ttm)
+
+        # --- Metrics & Ratios ---
+        streamable_mcp.tool()(get_key_metrics)
+        streamable_mcp.tool()(get_key_metrics_ttm)
+        streamable_mcp.tool()(get_financial_ratios)
+        streamable_mcp.tool()(get_financial_ratios_ttm)
+        streamable_mcp.tool()(get_financial_scores)
+        streamable_mcp.tool()(get_owner_earnings)
+        streamable_mcp.tool()(get_enterprise_values)
+
+        # --- Growth ---
+        streamable_mcp.tool()(get_income_statement_growth)
+        streamable_mcp.tool()(get_balance_sheet_growth)
+        streamable_mcp.tool()(get_cash_flow_growth)
+        streamable_mcp.tool()(get_financial_statement_growth)
+
+        # --- Segmentation ---
+        streamable_mcp.tool()(get_revenue_product_segmentation)
+        streamable_mcp.tool()(get_revenue_geographic_segmentation)
+
+        # --- Peer comparison ---
+        streamable_mcp.tool()(get_stock_peers)
+
         streamable_mcp.tool()(search_by_symbol)
         streamable_mcp.tool()(search_by_name)
         streamable_mcp.tool()(get_ratings_snapshot)

--- a/src/tools/company.py
+++ b/src/tools/company.py
@@ -63,7 +63,7 @@ async def get_company_profile(symbol: str) -> str:
         "## Additional Information",
         f"**Website**: {profile.get('website', 'N/A')}",
         f"**Exchange**: {profile.get('exchange', 'N/A')}",
-        f"**Founded**: {profile.get('ipoDate', 'N/A')}"
+        f"**IPO Date**: {profile.get('ipoDate', 'N/A')}"
     ]
     
     return "\n".join(result)

--- a/src/tools/peers.py
+++ b/src/tools/peers.py
@@ -1,0 +1,61 @@
+from typing import Dict, Any, Optional, List, Union
+
+from src.api.client import fmp_api_request
+
+# Helper function for formatting numbers with commas
+def format_number(value: Any) -> str:
+    """Format a number with commas, or return as-is if not a number"""
+    if isinstance(value, (int, float)):
+        return f"{value:,}"
+    return str(value)
+
+async def get_stock_peers(symbol: str) -> str:
+    """
+    Get stock peer companies for a given symbol.
+
+    This tool returns a list of peer companies as identified by
+    Financial Modeling Prep, including basic market context
+    (company name, price, market cap).
+
+    IMPORTANT:
+    - This is peer identification, NOT valuation
+    - Intended for downstream comparative analysis
+    """
+
+    raw = await fmp_api_request("stock-peers", {"symbol": symbol})
+
+    if raw is None:
+        return f"No peer data found for {symbol}"
+
+    # Normalise response shape
+    if isinstance(raw, list):
+        peers = raw
+    elif isinstance(raw, dict):
+        # Defensive fallback (shouldn't normally happen)
+        peers = [raw]
+    else:
+        return f"No peer data found for {symbol}"
+
+    if len(peers) == 0:
+        return f"No peer data found for {symbol}"
+
+    result = [f"# Stock Peers for {symbol}"]
+
+    for peer in peers:
+        peer_symbol = peer.get("symbol", "N/A")
+        name = peer.get("companyName", "Unknown")
+        price = peer.get("price")
+        mkt_cap = peer.get("mktCap")
+
+        line = f"- **{peer_symbol}** ({name})"
+
+        if price is not None:
+            line += f" | Price: {price}"
+
+        if mkt_cap is not None:
+            line += f" | Market Cap: {mkt_cap}"
+
+        result.append(line)
+
+    return "\n".join(result)
+

--- a/src/tools/statements.py
+++ b/src/tools/statements.py
@@ -309,7 +309,7 @@ async def get_cash_flow_statement(symbol: str, period: str = "annual", limit: in
         result.append("### Financing Activities")
 
         result.append(f"**Debt Issuance (Net)**: ${format_number(statement.get('netDebtIssuance', 'N/A'))}")
-        result.append(f"**Common Stock Issued**: ${format_number(statement.get('commonStockIssued', 'N/A'))}")
+        result.append(f"**Common Stock Issued**: ${format_number(statement.get('commonStockIssuance', 'N/A'))}")
         result.append(f"**Common Stock Repurchased**: ${format_number(statement.get('commonStockRepurchased', 'N/A'))}")
         dividends_paid = (statement.get('commonDividendsPaid')
                           or statement.get('netDividendsPaid')
@@ -318,7 +318,7 @@ async def get_cash_flow_statement(symbol: str, period: str = "annual", limit: in
         result.append(f"**Preferred Dividends Paid**: ${format_number(statement.get('preferredDividendsPaid', 'N/A'))}")
         result.append(f"**Income Taxes Paid**: ${format_number(statement.get('incomeTaxesPaid', 'N/A'))}")
         result.append(f"**Interest Paid**: ${format_number(statement.get('interestPaid', 'N/A'))}")
-        result.append(f"**Other Financing Activities**: ${format_number(statement.get('otherFinancingActivites', 'N/A'))}")
+        result.append(f"**Other Financing Activities**: ${format_number(statement.get('otherFinancingActivities', 'N/A'))}")
         result.append(f"**Net Financing Cash Flow**: ${format_number(statement.get('netCashUsedProvidedByFinancingActivities', 'N/A'))}")
 
         result.append("")

--- a/src/tools/statements.py
+++ b/src/tools/statements.py
@@ -14,6 +14,35 @@ def format_number(value: Any) -> str:
         return f"{value:,}"
     return str(value)
 
+async def fetch_fmp_stable(endpoint: str, symbol: str, extra_params: dict | None = None):
+    """
+    Generic helper for calling FMP Stable API endpoints.
+
+    This helper is intended for:
+    - TTM endpoints
+    - ratios
+    - metrics
+    - growth
+    - segmentation APIs
+
+    NOTE:
+    Legacy statement tools (annual/quarterly) still call fmp_api_request
+    directly and are intentionally left unchanged.
+    """
+    params = {"symbol": symbol}
+    if extra_params:
+        params.update(extra_params)
+
+    data = await fmp_api_request(endpoint, params)
+
+    if isinstance(data, dict) and "Error Message" in data:
+        return {
+            "error": "FMP API error",
+            "message": data["Error Message"],
+            "endpoint": endpoint
+        }
+
+    return data
 
 async def get_income_statement(symbol: str, period: str = "annual", limit: int = 1) -> str:
     """
@@ -115,3 +144,522 @@ async def get_income_statement(symbol: str, period: str = "annual", limit: int =
         result.append(f"**Weighted Average Shares Outstanding (Diluted)**: {format_number(statement.get('weightedAverageShsOutDil', 'N/A'))}")
     
     return "\n".join(result)
+
+async def get_balance_sheet(symbol: str, period: str = "annual", limit: int = 1) -> str:
+    """
+    Get balance sheet statement for a company
+
+    Args:
+        symbol: Stock ticker symbol (e.g., AAPL, MSFT, TSLA)
+        period: Data period - "annual" or "quarter"
+        limit: Number of periods to return (1-120)
+
+    Returns:
+        Balance sheet data
+    """
+    if period not in ["annual", "quarter"]:
+        return "Error: period must be 'annual' or 'quarter'"
+
+    if not 1 <= limit <= 120:
+        return "Error: limit must be between 1 and 120"
+
+    endpoint = "balance-sheet-statement"
+    params = {"symbol": symbol, "period": period, "limit": limit}
+
+    data = await fmp_api_request(endpoint, params)
+
+    if isinstance(data, dict) and "error" in data:
+        return f"Error fetching balance sheet for {symbol}: {data.get('message', 'Unknown error')}"
+
+    if not data or not isinstance(data, list):
+        return f"No balance sheet data found for symbol {symbol}"
+
+    result = [f"# Balance Sheet for {symbol}"]
+
+    for statement in data:
+        result.append(f"\n## Period: {statement.get('date', 'Unknown')}")
+        result.append(f"**Currency**: {statement.get('reportedCurrency', 'USD')}")
+        result.append(f"**Fiscal Year**: {statement.get('fiscalYear', 'N/A')}")
+        result.append(f"**Filing Date**: {statement.get('filingDate', 'N/A')}")
+        result.append("")
+
+        # Assets
+        result.append("### Assets")
+
+        # Current Assets
+        result.append(f"**Cash & Cash Equivalents**: ${format_number(statement.get('cashAndCashEquivalents', 'N/A'))}")
+        result.append(f"**Short-Term Investments**: ${format_number(statement.get('shortTermInvestments', 'N/A'))}")
+        result.append(f"**Net Receivables**: ${format_number(statement.get('netReceivables', 'N/A'))}")
+        result.append(f"**Inventory**: ${format_number(statement.get('inventory', 'N/A'))}")
+        result.append(f"**Other Current Assets**: ${format_number(statement.get('otherCurrentAssets', 'N/A'))}")
+        result.append(f"**Total Current Assets**: ${format_number(statement.get('totalCurrentAssets', 'N/A'))}")
+
+        # Non-Current Assets
+        result.append(f"**Property, Plant & Equipment (Net)**: ${format_number(statement.get('propertyPlantEquipmentNet', 'N/A'))}")
+        result.append(f"**Goodwill**: ${format_number(statement.get('goodwill', 'N/A'))}")
+        result.append(f"**Intangible Assets**: ${format_number(statement.get('intangibleAssets', 'N/A'))}")
+        result.append(f"**Goodwill & Intangibles**: ${format_number(statement.get('goodwillAndIntangibleAssets', 'N/A'))}")
+        result.append(f"**Long-Term Investments**: ${format_number(statement.get('longTermInvestments', 'N/A'))}")
+        result.append(f"**Tax Assets**: ${format_number(statement.get('taxAssets', 'N/A'))}")
+        result.append(f"**Other Non-Current Assets**: ${format_number(statement.get('otherNonCurrentAssets', 'N/A'))}")
+        result.append(f"**Total Assets**: ${format_number(statement.get('totalAssets', 'N/A'))}")
+
+        result.append("")
+
+        # Liabilities
+        result.append("### Liabilities")
+
+        # Current Liabilities
+        result.append(f"**Accounts Payable**: ${format_number(statement.get('accountPayables', 'N/A'))}")
+        result.append(f"**Short-Term Debt**: ${format_number(statement.get('shortTermDebt', 'N/A'))}")
+        result.append(f"**Tax Payables**: ${format_number(statement.get('taxPayables', 'N/A'))}")
+        result.append(f"**Deferred Revenue (Current)**: ${format_number(statement.get('deferredRevenue', 'N/A'))}")
+        result.append(f"**Other Current Liabilities**: ${format_number(statement.get('otherCurrentLiabilities', 'N/A'))}")
+        result.append(f"**Total Current Liabilities**: ${format_number(statement.get('totalCurrentLiabilities', 'N/A'))}")
+
+        # Non-Current Liabilities
+        result.append(f"**Long-Term Debt**: ${format_number(statement.get('longTermDebt', 'N/A'))}")
+        result.append(f"**Deferred Revenue (Non-Current)**: ${format_number(statement.get('deferredRevenueNonCurrent', 'N/A'))}")
+        result.append(f"**Deferred Tax Liabilities**: ${format_number(statement.get('deferredTaxLiabilitiesNonCurrent', 'N/A'))}")
+        result.append(f"**Other Non-Current Liabilities**: ${format_number(statement.get('otherNonCurrentLiabilities', 'N/A'))}")
+        result.append(f"**Total Liabilities**: ${format_number(statement.get('totalLiabilities', 'N/A'))}")
+
+        result.append("")
+
+        # Equity
+        result.append("### Shareholders’ Equity")
+
+        result.append(f"**Common Stock**: ${format_number(statement.get('commonStock', 'N/A'))}")
+        result.append(f"**Additional Paid-In Capital**: ${format_number(statement.get('additionalPaidInCapital', 'N/A'))}")
+        result.append(f"**Retained Earnings**: ${format_number(statement.get('retainedEarnings', 'N/A'))}")
+        result.append(f"**Accumulated OCI**: ${format_number(statement.get('accumulatedOtherComprehensiveIncomeLoss', 'N/A'))}")
+        result.append(f"**Total Stockholders’ Equity**: ${format_number(statement.get('totalStockholdersEquity', 'N/A'))}")
+        result.append(f"**Total Equity**: ${format_number(statement.get('totalEquity', 'N/A'))}")
+
+    return "\n".join(result)
+
+async def get_cash_flow_statement(symbol: str, period: str = "annual", limit: int = 1) -> str:
+    """
+    Get cash flow statement for a company
+
+    Args:
+        symbol: Stock ticker symbol
+        period: Data period - "annual" or "quarter"
+        limit: Number of periods to return (1-120)
+
+    Returns:
+        Cash flow statement data
+    """
+    if period not in ["annual", "quarter"]:
+        return "Error: period must be 'annual' or 'quarter'"
+
+    if not 1 <= limit <= 120:
+        return "Error: limit must be between 1 and 120"
+
+    endpoint = "cash-flow-statement"
+    params = {"symbol": symbol, "period": period, "limit": limit}
+
+    data = await fmp_api_request(endpoint, params)
+
+    if isinstance(data, dict) and "error" in data:
+        return f"Error fetching cash flow statement for {symbol}: {data.get('message', 'Unknown error')}"
+
+    if not data or not isinstance(data, list):
+        return f"No cash flow data found for symbol {symbol}"
+
+    result = [f"# Cash Flow Statement for {symbol}"]
+
+    for statement in data:
+        result.append(f"\n## Period: {statement.get('date', 'Unknown')}")
+        result.append(f"**Currency**: {statement.get('reportedCurrency', 'USD')}")
+        result.append(f"**Fiscal Year**: {statement.get('fiscalYear', 'N/A')}")
+        result.append("")
+
+        # Operating activities
+        result.append("### Operating Activities")
+
+        result.append(f"**Net Income**: ${format_number(statement.get('netIncome', 'N/A'))}")
+        result.append(f"**Depreciation & Amortization**: ${format_number(statement.get('depreciationAndAmortization', 'N/A'))}")
+        result.append(f"**Deferred Income Tax**: ${format_number(statement.get('deferredIncomeTax', 'N/A'))}")
+        result.append(f"**Stock-Based Compensation**: ${format_number(statement.get('stockBasedCompensation', 'N/A'))}")
+        result.append(f"**Change in Working Capital**: ${format_number(statement.get('changeInWorkingCapital', 'N/A'))}")
+        result.append(f"**Accounts Receivable**: ${format_number(statement.get('accountsReceivables', 'N/A'))}")
+        result.append(f"**Inventory**: ${format_number(statement.get('inventory', 'N/A'))}")
+        result.append(f"**Accounts Payable**: ${format_number(statement.get('accountsPayables', 'N/A'))}")
+        result.append(f"**Other Working Capital**: ${format_number(statement.get('otherWorkingCapital', 'N/A'))}")
+        result.append(f"**Operating Cash Flow**: ${format_number(statement.get('operatingCashFlow', 'N/A'))}")
+
+        result.append("")
+
+        # Investing activities
+        result.append("### Investing Activities")
+
+        result.append(f"**Capital Expenditure**: ${format_number(statement.get('capitalExpenditure', 'N/A'))}")
+        result.append(f"**Acquisitions (Net)**: ${format_number(statement.get('acquisitionsNet', 'N/A'))}")
+        result.append(f"**Purchases of Investments**: ${format_number(statement.get('purchasesOfInvestments', 'N/A'))}")
+        result.append(f"**Sales/Maturities of Investments**: ${format_number(statement.get('salesMaturitiesOfInvestments', 'N/A'))}")
+        result.append(f"**Other Investing Activities**: ${format_number(statement.get('otherInvestingActivities', 'N/A'))}")
+        result.append(f"**Net Investing Cash Flow**: ${format_number(statement.get('netCashUsedForInvestingActivites', 'N/A'))}")
+
+        result.append("")
+
+        # Financing activities
+        result.append("### Financing Activities")
+
+        result.append(f"**Debt Issuance (Net)**: ${format_number(statement.get('netDebtIssuance', 'N/A'))}")
+        result.append(f"**Common Stock Issued**: ${format_number(statement.get('commonStockIssued', 'N/A'))}")
+        result.append(f"**Common Stock Repurchased**: ${format_number(statement.get('commonStockRepurchased', 'N/A'))}")
+        result.append(f"**Dividends Paid**: ${format_number(statement.get('dividendsPaid', 'N/A'))}")
+        result.append(f"**Other Financing Activities**: ${format_number(statement.get('otherFinancingActivites', 'N/A'))}")
+        result.append(f"**Net Financing Cash Flow**: ${format_number(statement.get('netCashUsedProvidedByFinancingActivities', 'N/A'))}")
+
+        result.append("")
+
+        # Net change
+        result.append("### Cash Position")
+        result.append(f"**Net Change in Cash**: ${format_number(statement.get('netChangeInCash', 'N/A'))}")
+        result.append(f"**Cash at Beginning of Period**: ${format_number(statement.get('cashAtBeginningOfPeriod', 'N/A'))}")
+        result.append(f"**Cash at End of Period**: ${format_number(statement.get('cashAtEndOfPeriod', 'N/A'))}")
+        result.append(f"**Free Cash Flow**: ${format_number(statement.get('freeCashFlow', 'N/A'))}")
+
+    return "\n".join(result)
+
+# ============================================================================
+# Extended Financial Fundamentals (TTM, Metrics, Ratios, Growth, Segmentation)
+# ============================================================================
+
+# ----------------------------
+# TTM FINANCIAL STATEMENTS
+# ----------------------------
+
+async def get_income_statement_ttm(symbol: str) -> str:
+    """
+    Get Trailing Twelve Months (TTM) Income Statement.
+
+    IMPORTANT:
+    - This endpoint returns rolling 12-month values
+    - It is NOT fiscal-year or quarterly data
+    - Use this for valuation multiples and current profitability analysis
+    """
+    data = await fetch_fmp_stable("income-statement-ttm", symbol)
+
+    if not isinstance(data, dict):
+        return f"No TTM income statement data found for {symbol}"
+
+    result = [f"# Income Statement (TTM) for {symbol}"]
+    for key, value in data.items():
+        result.append(f"**{key}**: {format_number(value)}")
+
+    return "\n".join(result)
+
+
+async def get_balance_sheet_ttm(symbol: str) -> str:
+    """
+    Get Trailing Twelve Months (TTM) Balance Sheet.
+
+    IMPORTANT:
+    - Represents rolling 12-month snapshot
+    - Not equivalent to fiscal year-end balance sheet
+    """
+    data = await fetch_fmp_stable("balance-sheet-statement-ttm", symbol)
+
+    if not isinstance(data, dict):
+        return f"No TTM balance sheet data found for {symbol}"
+
+    result = [f"# Balance Sheet (TTM) for {symbol}"]
+    for key, value in data.items():
+        result.append(f"**{key}**: {format_number(value)}")
+
+    return "\n".join(result)
+
+
+async def get_cash_flow_statement_ttm(symbol: str) -> str:
+    """
+    Get Trailing Twelve Months (TTM) Cash Flow Statement.
+
+    IMPORTANT:
+    - Rolling 12-month cash flows
+    - Use for free cash flow and cash conversion analysis
+    """
+    data = await fetch_fmp_stable("cash-flow-statement-ttm", symbol)
+
+    if not isinstance(data, dict):
+        return f"No TTM cash flow data found for {symbol}"
+
+    result = [f"# Cash Flow Statement (TTM) for {symbol}"]
+    for key, value in data.items():
+        result.append(f"**{key}**: {format_number(value)}")
+
+    return "\n".join(result)
+
+
+# ----------------------------
+# KEY METRICS & RATIOS
+# ----------------------------
+
+async def get_key_metrics(symbol: str, limit: int = 5) -> str:
+    """
+    Get historical Key Metrics (annual / period-based).
+
+    NOT TTM.
+    """
+    data = await fetch_fmp_stable("key-metrics", symbol, {"limit": limit})
+
+    if not isinstance(data, list):
+        return f"No key metrics data found for {symbol}"
+
+    result = [f"# Key Metrics (Historical) for {symbol}"]
+    for row in data:
+        result.append(f"\n## Period: {row.get('date')}")
+        for key, value in row.items():
+            if key != "date":
+                result.append(f"**{key}**: {format_number(value)}")
+
+    return "\n".join(result)
+
+
+async def get_key_metrics_ttm(symbol: str) -> str:
+    """
+    Get Key Metrics using Trailing Twelve Months (TTM).
+
+    Use this for valuation and efficiency analysis.
+    """
+    data = await fetch_fmp_stable("key-metrics-ttm", symbol)
+
+    if not isinstance(data, dict):
+        return f"No TTM key metrics found for {symbol}"
+
+    result = [f"# Key Metrics (TTM) for {symbol}"]
+    for key, value in data.items():
+        result.append(f"**{key}**: {format_number(value)}")
+
+    return "\n".join(result)
+
+
+async def get_financial_ratios(symbol: str, limit: int = 5) -> str:
+    """
+    Get historical Financial Ratios (annual / period-based).
+
+    NOT TTM.
+    """
+    data = await fetch_fmp_stable("ratios", symbol, {"limit": limit})
+
+    if not isinstance(data, list):
+        return f"No financial ratios found for {symbol}"
+
+    result = [f"# Financial Ratios (Historical) for {symbol}"]
+    for row in data:
+        result.append(f"\n## Period: {row.get('date')}")
+        for key, value in row.items():
+            if key != "date":
+                result.append(f"**{key}**: {format_number(value)}")
+
+    return "\n".join(result)
+
+
+async def get_financial_ratios_ttm(symbol: str) -> str:
+    """
+    Get Financial Ratios using Trailing Twelve Months (TTM).
+    """
+    data = await fetch_fmp_stable("ratios-ttm", symbol)
+
+    if not isinstance(data, dict):
+        return f"No TTM financial ratios found for {symbol}"
+
+    result = [f"# Financial Ratios (TTM) for {symbol}"]
+    for key, value in data.items():
+        result.append(f"**{key}**: {format_number(value)}")
+
+    return "\n".join(result)
+
+async def get_financial_scores(symbol: str) -> str:
+    """
+    Get Financial Scores (Altman Z-score, Piotroski score, etc.).
+
+    Snapshot-style endpoint.
+    FMP API returns a list, but the client may normalise it to a dict.
+    """
+
+    raw = await fetch_fmp_stable("financial-scores", symbol)
+
+    # ---- NORMALISE RESPONSE ----
+    if raw is None:
+        return f"No financial scores found for {symbol}"
+
+    if isinstance(raw, list):
+        if len(raw) == 0:
+            return f"No financial scores found for {symbol}"
+        scores = raw[0]
+
+    elif isinstance(raw, dict):
+        # Client-side normalisation case
+        scores = raw
+
+    else:
+        return f"No financial scores found for {symbol}"
+
+    # ---- RENDER OUTPUT ----
+    lines = [f"# Financial Scores for {symbol}"]
+
+    for key, value in scores.items():
+        lines.append(f"**{key}**: {value}")
+
+    return "\n".join(lines)
+
+async def get_owner_earnings(symbol: str) -> str:
+    """
+    Get Owner Earnings data (Buffett-style earnings measure).
+    """
+    data = await fetch_fmp_stable("owner-earnings", symbol)
+
+    if not isinstance(data, dict):
+        return f"No owner earnings data found for {symbol}"
+
+    result = [f"# Owner Earnings for {symbol}"]
+    for key, value in data.items():
+        result.append(f"**{key}**: {format_number(value)}")
+
+    return "\n".join(result)
+
+
+async def get_enterprise_values(symbol: str, limit: int = 5) -> str:
+    """
+    Get historical Enterprise Value data.
+    """
+    data = await fetch_fmp_stable("enterprise-values", symbol, {"limit": limit})
+
+    if not isinstance(data, list):
+        return f"No enterprise value data found for {symbol}"
+
+    result = [f"# Enterprise Values for {symbol}"]
+    for row in data:
+        result.append(f"\n## Period: {row.get('date')}")
+        for key, value in row.items():
+            if key != "date":
+                result.append(f"**{key}**: {format_number(value)}")
+
+    return "\n".join(result)
+
+
+# ----------------------------
+# GROWTH APIs
+# ----------------------------
+
+async def get_income_statement_growth(symbol: str) -> str:
+    """
+    Get Income Statement growth rates (YoY).
+    """
+    data = await fetch_fmp_stable("income-statement-growth", symbol)
+
+    if not isinstance(data, list):
+        return f"No income statement growth data found for {symbol}"
+
+    result = [f"# Income Statement Growth for {symbol}"]
+    for row in data:
+        result.append(f"\n## Period: {row.get('date')}")
+        for key, value in row.items():
+            if key != "date":
+                result.append(f"**{key}**: {value}")
+
+    return "\n".join(result)
+
+
+async def get_balance_sheet_growth(symbol: str) -> str:
+    """
+    Get Balance Sheet growth rates (YoY).
+    """
+    data = await fetch_fmp_stable("balance-sheet-statement-growth", symbol)
+
+    if not isinstance(data, list):
+        return f"No balance sheet growth data found for {symbol}"
+
+    result = [f"# Balance Sheet Growth for {symbol}"]
+    for row in data:
+        result.append(f"\n## Period: {row.get('date')}")
+        for key, value in row.items():
+            if key != "date":
+                result.append(f"**{key}**: {value}")
+
+    return "\n".join(result)
+
+
+async def get_cash_flow_growth(symbol: str) -> str:
+    """
+    Get Cash Flow Statement growth rates (YoY).
+    """
+    data = await fetch_fmp_stable("cash-flow-statement-growth", symbol)
+
+    if not isinstance(data, list):
+        return f"No cash flow growth data found for {symbol}"
+
+    result = [f"# Cash Flow Statement Growth for {symbol}"]
+    for row in data:
+        result.append(f"\n## Period: {row.get('date')}")
+        for key, value in row.items():
+            if key != "date":
+                result.append(f"**{key}**: {value}")
+
+    return "\n".join(result)
+
+
+async def get_financial_statement_growth(symbol: str) -> str:
+    """
+    Get aggregated Financial Statement growth rates.
+    """
+    data = await fetch_fmp_stable("financial-statement-growth", symbol)
+
+    if not isinstance(data, list):
+        return f"No financial statement growth data found for {symbol}"
+
+    result = [f"# Financial Statement Growth for {symbol}"]
+    for row in data:
+        result.append(f"\n## Period: {row.get('date')}")
+        for key, value in row.items():
+            if key != "date":
+                result.append(f"**{key}**: {value}")
+
+    return "\n".join(result)
+
+
+# ----------------------------
+# REVENUE SEGMENTATION
+# ----------------------------
+
+async def get_revenue_product_segmentation(symbol: str) -> str:
+    """
+    Get revenue breakdown by product line.
+    """
+    data = await fetch_fmp_stable("revenue-product-segmentation", symbol)
+
+    if not isinstance(data, list):
+        return f"No product segmentation data found for {symbol}"
+
+    result = [f"# Revenue by Product for {symbol}"]
+    for row in data:
+        result.append(f"\n## Period: {row.get('date')}")
+        for key, value in row.items():
+            if key != "date":
+                result.append(f"**{key}**: {format_number(value)}")
+
+    return "\n".join(result)
+
+
+async def get_revenue_geographic_segmentation(symbol: str) -> str:
+    """
+    Get revenue breakdown by geographic region.
+    """
+    data = await fetch_fmp_stable("revenue-geographic-segmentation", symbol)
+
+    if not isinstance(data, list):
+        return f"No geographic segmentation data found for {symbol}"
+
+    result = [f"# Revenue by Geography for {symbol}"]
+    for row in data:
+        result.append(f"\n## Period: {row.get('date')}")
+        for key, value in row.items():
+            if key != "date":
+                result.append(f"**{key}**: {format_number(value)}")
+
+    return "\n".join(result)
+
+

--- a/src/tools/statements.py
+++ b/src/tools/statements.py
@@ -219,6 +219,8 @@ async def get_balance_sheet(symbol: str, period: str = "annual", limit: int = 1)
 
         # Non-Current Liabilities
         result.append(f"**Long-Term Debt**: ${format_number(statement.get('longTermDebt', 'N/A'))}")
+        result.append(f"**Total Debt**: ${format_number(statement.get('totalDebt', 'N/A'))}")
+        result.append(f"**Capital Lease Obligations**: ${format_number(statement.get('capitalLeaseObligations', 'N/A'))}")
         result.append(f"**Deferred Revenue (Non-Current)**: ${format_number(statement.get('deferredRevenueNonCurrent', 'N/A'))}")
         result.append(f"**Deferred Tax Liabilities**: ${format_number(statement.get('deferredTaxLiabilitiesNonCurrent', 'N/A'))}")
         result.append(f"**Other Non-Current Liabilities**: ${format_number(statement.get('otherNonCurrentLiabilities', 'N/A'))}")
@@ -309,7 +311,13 @@ async def get_cash_flow_statement(symbol: str, period: str = "annual", limit: in
         result.append(f"**Debt Issuance (Net)**: ${format_number(statement.get('netDebtIssuance', 'N/A'))}")
         result.append(f"**Common Stock Issued**: ${format_number(statement.get('commonStockIssued', 'N/A'))}")
         result.append(f"**Common Stock Repurchased**: ${format_number(statement.get('commonStockRepurchased', 'N/A'))}")
-        result.append(f"**Dividends Paid**: ${format_number(statement.get('dividendsPaid', 'N/A'))}")
+        dividends_paid = (statement.get('commonDividendsPaid')
+                          or statement.get('netDividendsPaid')
+                          or statement.get('dividendsPaid'))
+        result.append(f"**Dividends Paid**: ${format_number(dividends_paid if dividends_paid is not None else 'N/A')}")
+        result.append(f"**Preferred Dividends Paid**: ${format_number(statement.get('preferredDividendsPaid', 'N/A'))}")
+        result.append(f"**Income Taxes Paid**: ${format_number(statement.get('incomeTaxesPaid', 'N/A'))}")
+        result.append(f"**Interest Paid**: ${format_number(statement.get('interestPaid', 'N/A'))}")
         result.append(f"**Other Financing Activities**: ${format_number(statement.get('otherFinancingActivites', 'N/A'))}")
         result.append(f"**Net Financing Cash Flow**: ${format_number(statement.get('netCashUsedProvidedByFinancingActivities', 'N/A'))}")
 

--- a/src/tools/valuation.py
+++ b/src/tools/valuation.py
@@ -14,9 +14,16 @@ def _fmt(value) -> str:
 
 
 def _pct(value) -> str:
-    """Format a decimal as percentage string (0.087 -> '8.70%')."""
+    """Format a rate as percentage string.
+
+    FMP DCF endpoints return rates as already-percentage values (e.g. 14.9 = 14.9%),
+    not decimals (0.149). Guard: multiply by 100 only if value <= 1.0 (decimal form);
+    display as-is if > 1.0 (already percentage form). Prevents x100 double-application
+    bug (e.g. 14.9 -> 1490%) when FMP returns percentage-form values.
+    """
     if isinstance(value, (int, float)):
-        return f"{value * 100:.2f}%"
+        display = value * 100 if value <= 1.0 else value
+        return f"{display:.2f}%"
     return "N/A"
 
 

--- a/src/tools/valuation.py
+++ b/src/tools/valuation.py
@@ -1,0 +1,232 @@
+"""
+DCF valuation tools for the FMP MCP server.
+Exposes all four FMP stable/ discounted cash flow endpoints.
+"""
+from typing import Optional
+from src.api.client import fmp_api_request
+
+
+def _fmt(value) -> str:
+    """Format a number with commas, or return as-is if not a number."""
+    if isinstance(value, (int, float)):
+        return f"{value:,}"
+    return str(value)
+
+
+def _pct(value) -> str:
+    """Format a decimal as percentage string (0.087 -> '8.70%')."""
+    if isinstance(value, (int, float)):
+        return f"{value * 100:.2f}%"
+    return "N/A"
+
+
+def _bil(value) -> str:
+    """Format a large number in billions."""
+    if isinstance(value, (int, float)) and value != 0:
+        return f"${value / 1e9:.2f}B"
+    return "N/A"
+
+
+async def get_discounted_cash_flow(symbol: str) -> str:
+    """
+    Get FMP's standard DCF intrinsic value estimate for a stock.
+
+    Args:
+        symbol: Stock ticker symbol (e.g., AAPL)
+
+    Returns:
+        DCF value vs current stock price
+    """
+    data = await fmp_api_request("discounted-cash-flow", {"symbol": symbol})
+
+    if isinstance(data, dict) and ("error" in data or "Error Message" in data):
+        return f"Error fetching DCF for {symbol}: {data.get('message', data.get('Error Message', 'Unknown error'))}"
+
+    items = data if isinstance(data, list) else ([data] if data else [])
+    if not items:
+        return f"No DCF data found for {symbol}"
+
+    result = [f"# DCF Valuation: {symbol}"]
+    for item in items[:5]:
+        result.append(f"\n**Date**: {item.get('date', 'N/A')}")
+        result.append(f"**DCF (Intrinsic Value)**: ${_fmt(item.get('dcf', 'N/A'))}")
+        result.append(f"**Stock Price**: ${_fmt(item.get('stockPrice', 'N/A'))}")
+    return "\n".join(result)
+
+
+async def get_levered_discounted_cash_flow(symbol: str) -> str:
+    """
+    Get FMP's levered DCF (post-debt) valuation - reflects impact of financial obligations.
+
+    Args:
+        symbol: Stock ticker symbol (e.g., AAPL)
+
+    Returns:
+        Levered DCF value vs current stock price
+    """
+    data = await fmp_api_request("levered-discounted-cash-flow", {"symbol": symbol})
+
+    if isinstance(data, dict) and ("error" in data or "Error Message" in data):
+        return f"Error fetching levered DCF for {symbol}: {data.get('message', data.get('Error Message', 'Unknown error'))}"
+
+    items = data if isinstance(data, list) else ([data] if data else [])
+    if not items:
+        return f"No levered DCF data found for {symbol}"
+
+    result = [f"# Levered DCF Valuation: {symbol}"]
+    for item in items[:5]:
+        result.append(f"\n**Date**: {item.get('date', 'N/A')}")
+        result.append(f"**Levered DCF**: ${_fmt(item.get('dcf', 'N/A'))}")
+        result.append(f"**Stock Price**: ${_fmt(item.get('stockPrice', 'N/A'))}")
+    return "\n".join(result)
+
+
+async def get_custom_discounted_cash_flow(
+    symbol: str,
+    long_term_growth_rate: Optional[float] = None,
+    cost_of_equity: Optional[float] = None,
+    cost_of_debt: Optional[float] = None,
+    beta: Optional[float] = None,
+    risk_free_rate: Optional[float] = None,
+    market_risk_premium: Optional[float] = None,
+    tax_rate: Optional[float] = None,
+) -> str:
+    """
+    Get FMP's custom DCF model (WACC-based unlevered DCF).
+
+    Called with symbol only: returns FMP's own pre-built DCF assumptions
+    (WACC, terminal growth rate, UFCF projections, equity value per share).
+
+    Pass optional parameters to override assumptions for scenario analysis
+    (bull/base/bear). All rate parameters are decimals (0.04 = 4%).
+
+    Args:
+        symbol: Stock ticker symbol (e.g., AAPL)
+        long_term_growth_rate: Terminal growth rate override (e.g., 0.04)
+        cost_of_equity: Cost of equity override (e.g., 0.09)
+        cost_of_debt: Pre-tax cost of debt override (e.g., 0.04)
+        beta: Beta override (e.g., 1.2)
+        risk_free_rate: Risk-free rate override (e.g., 0.045)
+        market_risk_premium: Equity risk premium override (e.g., 0.055)
+        tax_rate: Corporate tax rate override (e.g., 0.21)
+
+    Returns:
+        Formatted DCF model table with key assumptions summary
+    """
+    params = {"symbol": symbol}
+    if long_term_growth_rate is not None:
+        params["longTermGrowthRate"] = long_term_growth_rate
+    if cost_of_equity is not None:
+        params["costOfEquity"] = cost_of_equity
+    if cost_of_debt is not None:
+        params["costOfDebt"] = cost_of_debt
+    if beta is not None:
+        params["beta"] = beta
+    if risk_free_rate is not None:
+        params["riskFreeRate"] = risk_free_rate
+    if market_risk_premium is not None:
+        params["marketRiskPremium"] = market_risk_premium
+    if tax_rate is not None:
+        params["taxRate"] = tax_rate
+
+    data = await fmp_api_request("custom-discounted-cash-flow", params)
+
+    if isinstance(data, dict) and ("error" in data or "Error Message" in data):
+        return f"Error fetching custom DCF for {symbol}: {data.get('message', data.get('Error Message', 'Unknown error'))}"
+    if not data or not isinstance(data, list) or len(data) == 0:
+        return f"No custom DCF data found for {symbol}"
+
+    result = [f"# Custom DCF Model: {symbol}\n"]
+    result.append("| Year | WACC | LT Growth | UFCF | Terminal Value | Equity Value/Share |")
+    result.append("|------|------|-----------|------|----------------|--------------------|")
+
+    for row in data:
+        year = row.get("year", "N/A")
+        result.append(
+            f"| {year} | {_pct(row.get('wacc'))} | {_pct(row.get('longTermGrowthRate'))} "
+            f"| {_bil(row.get('ufcf'))} | {_bil(row.get('terminalValue'))} "
+            f"| ${row.get('equityValuePerShare', 0):.2f} |"
+        )
+
+    # Summary of key assumptions from first projected year
+    projected = [r for r in data if isinstance(r.get('year'), (int, float)) and r.get('year', 0) > 2024]
+    if projected:
+        r = projected[0]
+        result.append(f"\n## Key Assumptions (FMP)")
+        result.append(f"**WACC**: {_pct(r.get('wacc'))}")
+        result.append(f"**Cost of Equity**: {_pct(r.get('costOfEquity'))}")
+        result.append(f"**After-Tax Cost of Debt**: {_pct(r.get('afterTaxCostOfDebt'))}")
+        result.append(f"**Beta**: {r.get('beta', 'N/A')}")
+        result.append(f"**Risk-Free Rate**: {_pct(r.get('riskFreeRate'))}")
+        result.append(f"**Market Risk Premium**: {_pct(r.get('marketRiskPremium'))}")
+        result.append(f"**Equity Weighting**: {_pct(r.get('equityWeighting'))}")
+        result.append(f"**Debt Weighting**: {_pct(r.get('debtWeighting'))}")
+        result.append(f"**Long-Term Growth Rate**: {_pct(r.get('longTermGrowthRate'))}")
+        result.append(f"**Enterprise Value**: {_bil(r.get('enterpriseValue'))}")
+        result.append(f"**Net Debt**: {_bil(r.get('netDebt'))}")
+        result.append(f"**Equity Value Per Share**: ${r.get('equityValuePerShare', 0):.2f}")
+
+    return "\n".join(result)
+
+
+async def get_custom_levered_dcf(
+    symbol: str,
+    long_term_growth_rate: Optional[float] = None,
+    cost_of_equity: Optional[float] = None,
+    cost_of_debt: Optional[float] = None,
+    beta: Optional[float] = None,
+    risk_free_rate: Optional[float] = None,
+    tax_rate: Optional[float] = None,
+) -> str:
+    """
+    Get FMP's custom LEVERED DCF (post-debt valuation with optional custom assumptions).
+
+    Similar to get_custom_discounted_cash_flow but uses levered free cash flows.
+    All rate parameters are decimals (0.04 = 4%).
+
+    Args:
+        symbol: Stock ticker symbol (e.g., AAPL)
+        long_term_growth_rate: Terminal growth rate override
+        cost_of_equity: Cost of equity override
+        cost_of_debt: Pre-tax cost of debt override
+        beta: Beta override
+        risk_free_rate: Risk-free rate override
+        tax_rate: Corporate tax rate override
+
+    Returns:
+        Levered DCF model with equity value per share
+    """
+    params = {"symbol": symbol}
+    if long_term_growth_rate is not None:
+        params["longTermGrowthRate"] = long_term_growth_rate
+    if cost_of_equity is not None:
+        params["costOfEquity"] = cost_of_equity
+    if cost_of_debt is not None:
+        params["costOfDebt"] = cost_of_debt
+    if beta is not None:
+        params["beta"] = beta
+    if risk_free_rate is not None:
+        params["riskFreeRate"] = risk_free_rate
+    if tax_rate is not None:
+        params["taxRate"] = tax_rate
+
+    data = await fmp_api_request("custom-levered-discounted-cash-flow", params)
+
+    if isinstance(data, dict) and ("error" in data or "Error Message" in data):
+        return f"Error fetching custom levered DCF for {symbol}: {data.get('message', data.get('Error Message', 'Unknown error'))}"
+    if not data or not isinstance(data, list) or len(data) == 0:
+        return f"No custom levered DCF data found for {symbol}"
+
+    result = [f"# Custom Levered DCF: {symbol}\n"]
+    result.append("| Year | WACC | LT Growth | LFCF | Terminal Value | Equity Value/Share |")
+    result.append("|------|------|-----------|------|----------------|--------------------|")
+
+    for row in data:
+        year = row.get("year", "N/A")
+        result.append(
+            f"| {year} | {_pct(row.get('wacc'))} | {_pct(row.get('longTermGrowthRate'))} "
+            f"| {_bil(row.get('lfcf', row.get('ufcf')))} | {_bil(row.get('terminalValue'))} "
+            f"| ${row.get('equityValuePerShare', 0):.2f} |"
+        )
+
+    return "\n".join(result)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,7 +37,8 @@ def clean_modules():
         'src.tools.crypto',
         'src.tools.forex',
         'src.tools.technical_indicators',
-        'src.resources.company', 
+        'src.tools.valuation',
+        'src.resources.company',
         'src.resources.market',
         'src.prompts.templates'
     ]
@@ -2544,4 +2545,65 @@ def mock_most_active_response():
             "changesPercentage": -1.32,
             "volume": 87250000
         }
+    ]
+
+@pytest.fixture
+def mock_simple_dcf_response():
+    """Simple DCF response (list of dicts with date, dcf, stockPrice)"""
+    return [
+        {
+            "date": "2024-09-28",
+            "symbol": "AAPL",
+            "dcf": 149.50,
+            "stockPrice": 228.0,
+        }
+    ]
+
+
+@pytest.fixture
+def mock_dcf_response():
+    """Full custom DCF response (2 rows: 1 historical + 1 projected)"""
+    return [
+        {
+            "year": 2020,
+            "symbol": "AAPL",
+            "wacc": 0.0873,
+            "longTermGrowthRate": 0.04,
+            "ufcf": 73500000000,
+            "terminalValue": 2100000000000,
+            "presentTerminalValue": 1800000000000,
+            "equityValuePerShare": 142.10,
+            "costOfEquity": 0.092,
+            "costofDebt": 0.03,
+            "afterTaxCostOfDebt": 0.026,
+            "beta": 1.24,
+            "riskFreeRate": 0.045,
+            "marketRiskPremium": 0.055,
+            "equityWeighting": 0.96,
+            "debtWeighting": 0.04,
+            "taxRate": 0.147,
+            "enterpriseValue": 2850000000000,
+            "netDebt": -50000000000,
+        },
+        {
+            "year": 2025,
+            "symbol": "AAPL",
+            "wacc": 0.0873,
+            "longTermGrowthRate": 0.04,
+            "ufcf": 95000000000,
+            "terminalValue": 2500000000000,
+            "presentTerminalValue": 2100000000000,
+            "equityValuePerShare": 149.00,
+            "costOfEquity": 0.092,
+            "costofDebt": 0.03,
+            "afterTaxCostOfDebt": 0.026,
+            "beta": 1.24,
+            "riskFreeRate": 0.045,
+            "marketRiskPremium": 0.055,
+            "equityWeighting": 0.96,
+            "debtWeighting": 0.04,
+            "taxRate": 0.147,
+            "enterpriseValue": 3100000000000,
+            "netDebt": -50000000000,
+        },
     ]

--- a/tests/test_peers.py
+++ b/tests/test_peers.py
@@ -1,0 +1,68 @@
+"""
+Tests for stock peer comparison tools.
+
+NOTE ON TEST STRATEGY
+---------------------
+We do NOT test every possible peer-related scenario.
+Instead, this file provides representative coverage for:
+
+- Correct endpoint usage ("stock-peers")
+- Handling of list-based peer responses
+- Rendering of key peer attributes (symbol, name, price, market cap)
+
+This mirrors the approach used across the repository:
+test one representative tool per functional category.
+"""
+
+import pytest
+from unittest.mock import patch
+
+
+@pytest.mark.asyncio
+@patch("src.tools.peers.fmp_api_request")
+async def test_get_stock_peers(mock_request):
+    """Test stock peers tool with representative peer data"""
+
+    mock_request.return_value = [
+        {
+            "symbol": "AAPL",
+            "companyName": "Apple Inc.",
+            "price": 259.96,
+            "mktCap": 3841260530130,
+        },
+        {
+            "symbol": "MSFT",
+            "companyName": "Microsoft Corporation",
+            "price": 420.12,
+            "mktCap": 3100000000000,
+        },
+    ]
+
+    from src.tools.peers import get_stock_peers
+
+    result = await get_stock_peers("AAPL")
+
+    assert isinstance(result, str)
+    assert "# Stock Peers for AAPL" in result
+
+    # Verify peer rendering
+    assert "**AAPL**" in result
+    assert "**MSFT**" in result
+    assert "Apple Inc." in result
+    assert "Microsoft Corporation" in result
+    assert "Market Cap" in result
+    assert "Price" in result
+
+
+@pytest.mark.asyncio
+@patch("src.tools.peers.fmp_api_request")
+async def test_get_stock_peers_empty(mock_request):
+    """Test stock peers tool with empty response"""
+
+    mock_request.return_value = []
+
+    from src.tools.peers import get_stock_peers
+
+    result = await get_stock_peers("AAPL")
+
+    assert "No peer data found for AAPL" in result

--- a/tests/test_statements.py
+++ b/tests/test_statements.py
@@ -148,3 +148,154 @@ async def test_get_income_statement_invalid_limit():
     # Execute with invalid limit (too high)
     result = await get_income_statement(symbol="AAPL", limit=121)
     assert "Error: limit must be between 1 and 120" in result
+
+# ============================================================================
+# EXTENDED STATEMENT & FUNDAMENTALS TESTS
+# ============================================================================
+
+"""
+NOTE ON TEST STRATEGY
+---------------------
+This test file does NOT exhaustively test every statement / metric / ratio tool.
+
+Instead, it follows a *representative coverage strategy*:
+- Core financial statements are tested individually (Income, Balance Sheet, Cash Flow)
+- One tool per extended category is tested to validate:
+  - endpoint wiring
+  - response shape handling
+  - formatting logic
+  - error handling
+
+This keeps the test suite maintainable while protecting against regressions
+in the most failure-prone areas.
+"""
+
+
+@pytest.mark.asyncio
+@patch("src.api.client.fmp_api_request")
+async def test_get_balance_sheet_tool(mock_request):
+    """Representative test for balance sheet statement"""
+
+    mock_request.return_value = [
+        {
+            "date": "2023-09-30",
+            "reportedCurrency": "USD",
+            "totalAssets": 100000,
+            "totalLiabilities": 60000,
+            "totalStockholdersEquity": 40000,
+        }
+    ]
+
+    from src.tools.statements import get_balance_sheet
+
+    result = await get_balance_sheet("AAPL")
+
+    assert "# Balance Sheet for AAPL" in result
+    assert "Total Assets" in result
+    assert "Total Liabilities" in result
+    assert "Total Stockholders’ Equity" in result
+
+
+@pytest.mark.asyncio
+@patch("src.api.client.fmp_api_request")
+async def test_get_cash_flow_statement_tool(mock_request):
+    """Representative test for cash flow statement"""
+
+    mock_request.return_value = [
+        {
+            "date": "2023-09-30",
+            "netIncome": 50000,
+            "operatingCashFlow": 62000,
+            "freeCashFlow": 45000,
+        }
+    ]
+
+    from src.tools.statements import get_cash_flow_statement
+
+    result = await get_cash_flow_statement("AAPL")
+
+    assert "# Cash Flow Statement for AAPL" in result
+    assert "Operating Activities" in result
+    assert "Free Cash Flow" in result
+
+
+@pytest.mark.asyncio
+@patch("src.tools.statements.fetch_fmp_stable")
+async def test_get_income_statement_ttm(mock_fetch):
+    """Representative test for TTM statement (dict response)"""
+
+    mock_fetch.return_value = {
+        "revenue": 380000,
+        "netIncome": 97000,
+    }
+
+    from src.tools.statements import get_income_statement_ttm
+
+    result = await get_income_statement_ttm("AAPL")
+
+    assert "# Income Statement (TTM) for AAPL" in result
+    assert "revenue" in result.lower()
+    assert "netIncome" in result
+
+
+@pytest.mark.asyncio
+@patch("src.tools.statements.fetch_fmp_stable")
+async def test_get_financial_ratios_ttm(mock_fetch):
+    """Representative test for TTM financial ratios"""
+
+    mock_fetch.return_value = {
+        "peRatioTTM": 28.5,
+        "priceToSalesRatioTTM": 7.2,
+    }
+
+    from src.tools.statements import get_financial_ratios_ttm
+
+    result = await get_financial_ratios_ttm("AAPL")
+
+    assert "# Financial Ratios (TTM) for AAPL" in result
+    assert "peRatioTTM" in result
+    assert "priceToSalesRatioTTM" in result
+
+
+@pytest.mark.asyncio
+@patch("src.tools.statements.fetch_fmp_stable")
+async def test_get_financial_scores_snapshot(mock_fetch):
+    """Representative test for snapshot-style endpoint"""
+
+    mock_fetch.return_value = [
+        {
+            "symbol": "AAPL",
+            "altmanZScore": 9.48,
+            "piotroskiScore": 5,
+        }
+    ]
+
+    from src.tools.statements import get_financial_scores
+
+    result = await get_financial_scores("AAPL")
+
+    assert "# Financial Scores for AAPL" in result
+    assert "altmanZScore" in result
+    assert "piotroskiScore" in result
+
+
+@pytest.mark.asyncio
+@patch("src.tools.statements.fetch_fmp_stable")
+async def test_get_revenue_product_segmentation(mock_fetch):
+    """Representative test for revenue segmentation"""
+
+    mock_fetch.return_value = [
+        {
+            "date": "2023-09-30",
+            "iPhone": 200000,
+            "Services": 85000,
+        }
+    ]
+
+    from src.tools.statements import get_revenue_product_segmentation
+
+    result = await get_revenue_product_segmentation("AAPL")
+
+    assert "# Revenue by Product for AAPL" in result
+    assert "iPhone" in result
+    assert "Services" in result

--- a/tests/test_valuation.py
+++ b/tests/test_valuation.py
@@ -1,0 +1,149 @@
+"""
+Tests for DCF valuation tools
+"""
+import pytest
+from unittest.mock import patch
+
+
+@pytest.mark.asyncio
+@patch('src.api.client.fmp_api_request')
+async def test_get_discounted_cash_flow(mock_request, mock_simple_dcf_response):
+    """Test standard DCF tool with list response"""
+    mock_request.return_value = mock_simple_dcf_response
+
+    from src.tools.valuation import get_discounted_cash_flow
+
+    result = await get_discounted_cash_flow(symbol="AAPL")
+
+    mock_request.assert_called_once_with("discounted-cash-flow", {"symbol": "AAPL"})
+
+    assert isinstance(result, str)
+    assert "# DCF Valuation: AAPL" in result
+    assert "DCF (Intrinsic Value)" in result
+    assert "Stock Price" in result
+    assert "2024-09-28" in result
+
+
+@pytest.mark.asyncio
+@patch('src.api.client.fmp_api_request')
+async def test_get_discounted_cash_flow_single_dict(mock_request):
+    """Test standard DCF when FMP returns a dict instead of a list"""
+    mock_request.return_value = {"date": "2024-09-28", "dcf": 149.50, "stockPrice": 228.0}
+
+    from src.tools.valuation import get_discounted_cash_flow
+
+    result = await get_discounted_cash_flow(symbol="AAPL")
+
+    assert isinstance(result, str)
+    assert "# DCF Valuation: AAPL" in result
+    assert "DCF (Intrinsic Value)" in result
+
+
+@pytest.mark.asyncio
+@patch('src.api.client.fmp_api_request')
+async def test_get_discounted_cash_flow_error(mock_request):
+    """Test standard DCF returns friendly error string on API failure"""
+    mock_request.return_value = {"error": "symbol not found", "message": "Symbol FAKE not found"}
+
+    from src.tools.valuation import get_discounted_cash_flow
+
+    result = await get_discounted_cash_flow(symbol="FAKE")
+
+    assert isinstance(result, str)
+    assert "Error fetching DCF for FAKE" in result
+
+
+@pytest.mark.asyncio
+@patch('src.api.client.fmp_api_request')
+async def test_get_levered_discounted_cash_flow(mock_request, mock_simple_dcf_response):
+    """Test levered DCF tool"""
+    mock_request.return_value = mock_simple_dcf_response
+
+    from src.tools.valuation import get_levered_discounted_cash_flow
+
+    result = await get_levered_discounted_cash_flow(symbol="AAPL")
+
+    mock_request.assert_called_once_with("levered-discounted-cash-flow", {"symbol": "AAPL"})
+
+    assert isinstance(result, str)
+    assert "# Levered DCF Valuation: AAPL" in result
+    assert "Levered DCF" in result
+    assert "Stock Price" in result
+
+
+@pytest.mark.asyncio
+@patch('src.api.client.fmp_api_request')
+async def test_get_custom_discounted_cash_flow_default(mock_request, mock_dcf_response):
+    """Test custom DCF with no overrides - checks table and assumptions section"""
+    mock_request.return_value = mock_dcf_response
+
+    from src.tools.valuation import get_custom_discounted_cash_flow
+
+    result = await get_custom_discounted_cash_flow(symbol="AAPL")
+
+    mock_request.assert_called_once_with("custom-discounted-cash-flow", {"symbol": "AAPL"})
+
+    assert isinstance(result, str)
+    assert "# Custom DCF Model: AAPL" in result
+    # Table header
+    assert "| Year | WACC | LT Growth | UFCF | Terminal Value | Equity Value/Share |" in result
+    # Key assumptions section (from projected year)
+    assert "## Key Assumptions (FMP)" in result
+    assert "**WACC**:" in result
+    assert "**Cost of Equity**:" in result
+    assert "**Long-Term Growth Rate**:" in result
+    assert "**Equity Value Per Share**:" in result
+
+
+@pytest.mark.asyncio
+@patch('src.api.client.fmp_api_request')
+async def test_get_custom_discounted_cash_flow_with_overrides(mock_request, mock_dcf_response):
+    """Test custom DCF passes override params to API"""
+    mock_request.return_value = mock_dcf_response
+
+    from src.tools.valuation import get_custom_discounted_cash_flow
+
+    result = await get_custom_discounted_cash_flow(
+        symbol="AAPL",
+        long_term_growth_rate=0.045,
+        beta=1.3,
+    )
+
+    mock_request.assert_called_once_with(
+        "custom-discounted-cash-flow",
+        {"symbol": "AAPL", "longTermGrowthRate": 0.045, "beta": 1.3},
+    )
+
+    assert isinstance(result, str)
+    assert "# Custom DCF Model: AAPL" in result
+
+
+@pytest.mark.asyncio
+@patch('src.api.client.fmp_api_request')
+async def test_get_custom_levered_dcf_default(mock_request, mock_dcf_response):
+    """Test custom levered DCF happy path"""
+    mock_request.return_value = mock_dcf_response
+
+    from src.tools.valuation import get_custom_levered_dcf
+
+    result = await get_custom_levered_dcf(symbol="AAPL")
+
+    mock_request.assert_called_once_with("custom-levered-discounted-cash-flow", {"symbol": "AAPL"})
+
+    assert isinstance(result, str)
+    assert "# Custom Levered DCF: AAPL" in result
+    assert "| Year | WACC | LT Growth | LFCF | Terminal Value | Equity Value/Share |" in result
+
+
+@pytest.mark.asyncio
+@patch('src.api.client.fmp_api_request')
+async def test_get_custom_dcf_no_data(mock_request):
+    """Test custom DCF returns friendly message when API returns empty list"""
+    mock_request.return_value = []
+
+    from src.tools.valuation import get_custom_discounted_cash_flow
+
+    result = await get_custom_discounted_cash_flow(symbol="AAPL")
+
+    assert isinstance(result, str)
+    assert "No custom DCF data found for AAPL" in result


### PR DESCRIPTION
## Summary

This PR extends the Financial Modeling Prep (FMP) MCP server with additional financial statement coverage as the original statements.py file only covered the extraction of income_sheet data but not cashflow statements or balance sheet, peer comparison functionality, and representative unit tests.

## Key Changes

### New & Extended Tools
- Extended financial statement tools:
 - balance sheet and cash flow statements (annual + quarterly) 
 - TTM income, balance sheet, and cash flow statements
  - Financial ratios and key metrics (annual + TTM)
  - Financial scores (Altman Z, Piotroski, etc.)
  - Financial statement growth metrics
  - Revenue segmentation (product & geographic)
- Added stock peer comparison tool using FMP stable API
- Added FMP's stable/ discounted cash flow endpoints (NOTE - There is an error on the FMP API output where the % are not normalized ie it returns the value of 8.05 instead of 0.0805)

### MCP Server Updates
- Updated tool registration and descriptions in `src/server.py`
- Added a top-level `server.py` entrypoint to resolve import/path issues when running under Claude Desktop (STDIO MCP execution)

### Tests
- Extended `test_statements.py` using a representative-test strategy:
  - Core period statements (income, balance sheet, cash flow)
  - TTM, growth, ratios, scores, and segmentation
- Added `test_peers.py` for stock peer comparison tool

## Notes
- Uses only FMP stable endpoints (no legacy endpoints)
- Representative testing is intentional to balance coverage and runtime
- Designed to be LLM-friendly with verbose tool descriptions to avoid confusion between
  annual, quarterly, and TTM endpoints